### PR TITLE
RSS Portlet Customization

### DIFF
--- a/pleiades/notredame/browser/configure.zcml
+++ b/pleiades/notredame/browser/configure.zcml
@@ -134,4 +134,11 @@
         directory="template_overrides"
         layer=".interfaces.IPlonethemeNotredameLayer" />
 
+    <!-- Customized RSS Portlet for toots -->
+    <plone:portletRenderer
+        portlet="plone.app.portlets.portlets.rss.IRSSPortlet"
+        class=".portlets.PleiadesRSSRenderer"
+        layer=".interfaces.IPlonethemeNotredameLayer"
+        />
+
 </configure>

--- a/pleiades/notredame/browser/portlets.py
+++ b/pleiades/notredame/browser/portlets.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from DateTime import DateTime
+from DateTime.interfaces import DateTimeError
+from plone.app.portlets.portlets.rss import FEED_DATA
+from plone.app.portlets.portlets.rss import Renderer as RSSRenderer
+from plone.app.portlets.portlets.rss import RSSFeed
+from Products.Five.browser.pagetemplatefile import ZopeTwoPageTemplateFile
+
+
+class PleiadesRSSFeed(RSSFeed):
+
+    def _buildItemDict(self, item):
+        # Don't error when title is missing, add formatted pubdate
+        link = item.links[0]['href']
+        title = item.get('title')
+        if not title:
+            pubdate = datetime(*item.published_parsed[:7])
+            pubdate = pubdate.strftime("%d %B %Y")
+        itemdict = {
+            'title': title,
+            'pubdate': pubdate,
+            'url': link,
+            'summary': item.get('description', ''),
+        }
+        if hasattr(item, "updated"):
+            try:
+                itemdict['updated'] = DateTime(item.updated)
+            except DateTimeError:
+                # It's okay to drop it because in the
+                # template, this is checked with
+                # ``exists:``
+                pass
+
+        return itemdict
+
+
+class PleiadesRSSRenderer(RSSRenderer):
+
+    render_full = ZopeTwoPageTemplateFile('templates/rss.pt')
+
+    def _getFeed(self):
+        # Use our custom feed generator class
+        feed = FEED_DATA.get(self.data.url, None)
+        if feed is None:
+            # create it
+            feed = FEED_DATA[self.data.url] = PleiadesRSSFeed(self.data.url, self.data.timeout)
+        return feed

--- a/pleiades/notredame/browser/templates/rss.pt
+++ b/pleiades/notredame/browser/templates/rss.pt
@@ -1,0 +1,61 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:omit-tag="">
+<dl class="portlet portletRss"
+    i18n:domain="plone"
+    tal:condition="view/enabled">
+
+    <dt class="portletHeader">
+        <span class="portletTopLeft"></span>
+        <a href=""
+           tal:attributes="href view/siteurl"
+           tal:omit-tag="not:view/siteurl"
+           tal:content="view/title"
+           class="tile">
+            Tags
+        </a>
+        <span class="portletTopRight"></span>
+    </dt>
+    <tal:rss tal:condition="view/feedAvailable"
+                tal:define="toLocalizedTime nocall:context/@@plone/toLocalizedTime"
+                tal:repeat="item view/items">
+        <dd class="portletItem oddrow"
+            tal:define="oddrow repeat/item/odd"
+            tal:attributes="class python:oddrow and 'portletItem even' or 'portletItem odd'">
+
+            <a href="#"
+                tal:attributes="href item/url"
+                class="tile">
+                <tal:title tal:condition="item/title">
+                <span tal:replace="item/title">
+                    Title
+                </span>
+                <span class="portletItemDetails"
+                      tal:condition="exists:item/updated">
+                      <span tal:omit-tag="" tal:content="python:toLocalizedTime(item['updated'])">19.02.2007</span>
+                </span>
+                </tal:title>
+                <tal:toot tal:condition="not:item/title">
+                    <span tal:replace="item/pubdate">
+                        Title
+                    </span>
+                </tal:toot>
+            </a>
+            <tal:toot tal:condition="not:item/title">
+                <p tal:content="structure item/summary" tal:condition="item/summary|nothing">Summary</p>
+            </tal:toot>
+        </dd>
+    </tal:rss>
+    <dd class="portletFooter" tal:condition="view/feedAvailable">
+        <a href=""
+           tal:condition="view/siteurl"
+           tal:attributes="href view/siteurl">
+           <span class="hiddenStructure"><span tal:replace="view/title" /> - </span>
+           <span i18n:translate="box_morelink">More&hellip;</span>
+        </a>
+        <span class="portletBottomLeft"></span>
+        <span class="portletBottomRight"></span>
+    </dd>
+</dl>
+</html>

--- a/pleiades/notredame/browser/templates/rss.pt
+++ b/pleiades/notredame/browser/templates/rss.pt
@@ -42,9 +42,9 @@
                     </span>
                 </tal:toot>
             </a>
-            <tal:toot tal:condition="not:item/title">
-                <p tal:content="structure item/summary" tal:condition="item/summary|nothing">Summary</p>
-            </tal:toot>
+            <div class="tootBody" tal:condition="not:item/title">
+                <p tal:replace="structure item/summary" tal:condition="item/summary|nothing">Summary</p>
+            </div>
         </dd>
     </tal:rss>
     <dd class="portletFooter" tal:condition="view/feedAvailable">

--- a/pleiades/notredame/skins/pleiades_notredame_styles/public.css.dtml
+++ b/pleiades/notredame/skins/pleiades_notredame_styles/public.css.dtml
@@ -359,6 +359,30 @@ dl.ReferenceList dt {
 dl.ReferenceList dd ul {
   margin-left: 3em;
 }
+
+/* RSS portlet customizations */
+.portlet.portletRss a, .portlet.portletRss a.tile {
+    color: #2575AD;
+}
+
+.portlet.portletRss a.tile {
+    font-weight: bold;
+}
+
+.portlet.portletRss a:hover {
+    color: #036;
+    text-decoration: underline;
+}
+
+.portletRss .tootBody p {
+  display: none;
+}
+
+.portletRss .tootBody p:nth-child(1), dl.portletRss .tootBody p:nth-child(2) {
+  display: block;
+}
+
+
 /* YOUR CSS RULES STOP HERE */
 
 /* </dtml-with> */


### PR DESCRIPTION
Implements some customizations to the RSS portlet to support Mastodon style RSS with no titles. Should behave identically to the standard RSS portlet except when no title is present, in which case it will render the publication date in place of the linked title and include the HTML summary text. Refs isawnyu/pleiades-gazetteer#513